### PR TITLE
cli: Fix python import

### DIFF
--- a/cli/client.py
+++ b/cli/client.py
@@ -15,7 +15,7 @@ import signal
 import time
 
 from prompt_toolkit import prompt
-from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 


### PR DESCRIPTION
The import path of WordCompleter has changed in prompt_toolkit. With this change it works with newer versions.